### PR TITLE
Added -2, -6 and -15 as allowable exit codes in smoke test

### DIFF
--- a/common/autoware_testing/autoware_testing/smoke_test.py
+++ b/common/autoware_testing/autoware_testing/smoke_test.py
@@ -92,4 +92,4 @@ class DummyTest(unittest.TestCase):
 class TestProcessOutput(unittest.TestCase):
     def test_exit_code(self, proc_output, proc_info):
         # Check that process exits with code 0
-        launch_testing.asserts.assertExitCodes(proc_info)
+        launch_testing.asserts.assertExitCodes(proc_info, [0, -2, -6, -15])

--- a/common/autoware_testing/autoware_testing/smoke_test.py
+++ b/common/autoware_testing/autoware_testing/smoke_test.py
@@ -91,5 +91,5 @@ class DummyTest(unittest.TestCase):
 @launch_testing.post_shutdown_test()
 class TestProcessOutput(unittest.TestCase):
     def test_exit_code(self, proc_output, proc_info):
-        # Check that process exits with code 0
+        # Check that process exits with code 0(success), termination request, SIGINT or SIGTERM codes
         launch_testing.asserts.assertExitCodes(proc_info, [0, -2, -6, -15])


### PR DESCRIPTION
The suggestion in https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/merge_requests/1300/diffs?commit_id=c5894f8b125dbe734c85abb4376f063122a09a90 would eliminate all smoke test errors in current port of galactic ade environment