### PR TITLE
Add python launch files and modfiy default_ad_api

### DIFF
--- a/planning/external_velocity_limit_selector/launch/external_velocity_limit_selector.launch.py
+++ b/planning/external_velocity_limit_selector/launch/external_velocity_limit_selector.launch.py
@@ -1,0 +1,90 @@
+# Copyright 2023 U Power Robotics, USA
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from ament_index_python.packages import get_package_share_path
+import os
+
+
+def generate_launch_description():
+
+    pkg_share_path = get_package_share_path("external_velocity_limit_selector")
+    # arguments
+    # common param
+    common_param_path_arg = DeclareLaunchArgument(
+        name="common_param_path",
+        default_value=os.path.join(
+            pkg_share_path,
+            "config/default_common.param.yaml",
+        )
+    )
+
+    param_path_arg = DeclareLaunchArgument(
+        name="param_path",
+        default_value=os.path.join(
+            pkg_share_path,
+            "config/default.param.yaml",
+        )
+    )
+
+    # input/output
+    input_velocity_limit_from_api_arg = DeclareLaunchArgument(
+        name="input_velocity_limit_from_api",
+        default_value="/planning/scenario_planning/max_velocity_default",
+    )
+
+    input_velocity_limit_from_internal_arg = DeclareLaunchArgument(
+        name="input_velocity_limit_from_internal",
+        default_value="/planning/scenario_planning/max_velocity_candidates",
+    )
+
+    input_velocity_limit_clear_command_from_internal_arg = DeclareLaunchArgument(
+        name="input_velocity_limit_clear_command_from_internal",
+        default_value="/planning/scenario_planning/clear_velocity_limit",
+    )
+
+    output_velocity_limit_from_selector_arg = DeclareLaunchArgument(
+        name="output_velocity_limit_from_selector",
+        default_value="/planning/scenario_planning/max_velocity",
+    )
+
+    output_debug_string_arg = DeclareLaunchArgument(
+        name="output_debug_string",
+        default_value="/planning/scenario_planning/external_velocity_limit_selector/debug",
+    )
+
+    external_velocity_limit_selector_node = Node(
+        package="external_velocity_limit_selector",
+        executable="external_velocity_limit_selector",
+        name="external_velocity_limit_selector",
+        output="screen",
+        remappings=[
+            ("input/velocity_limit_from_api",
+             LaunchConfiguration("input_velocity_limit_from_api")),
+            ("input/velocity_limit_from_internal",
+             LaunchConfiguration("input_velocity_limit_from_internal")),
+            ("input/velocity_limit_clear_command_from_internal",
+             LaunchConfiguration("input_velocity_limit_clear_command_from_internal")),
+            ("output/external_velocity_limit",
+             LaunchConfiguration("output_velocity_limit_from_selector")),
+            ("output/debug", LaunchConfiguration("output_debug_string")),
+        ],
+        parameters=[
+            LaunchConfiguration("common_param_path"),
+            LaunchConfiguration("param_path"),
+            {"use_sim_time": LaunchConfiguration("use_sim_time")},
+        ],
+    )
+
+    return LaunchDescription([
+        common_param_path_arg,
+        param_path_arg,
+        input_velocity_limit_from_api_arg,
+        input_velocity_limit_from_internal_arg,
+        input_velocity_limit_clear_command_from_internal_arg,
+        output_velocity_limit_from_selector_arg,
+        output_debug_string_arg,
+        external_velocity_limit_selector_node,
+    ])

--- a/planning/mission_planner/launch/goal_pose_visualizer.launch.py
+++ b/planning/mission_planner/launch/goal_pose_visualizer.launch.py
@@ -1,0 +1,40 @@
+# Copyright 2023 U Power Robotics, USA
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+
+
+def generate_launch_description():
+
+    # arguments
+    route_topic_name_arg = DeclareLaunchArgument(
+        name="route_topic_name",
+        default_value="/planning/mission_planning/route",
+    )
+
+    echo_back_goal_pose_topic_name_arg = DeclareLaunchArgument(
+        name="echo_back_goal_pose_topic_name",
+        default_value="/planning/mission_planning/echo_back_goal_pose",
+    )
+
+    goal_pose_visualizer_node = Node(
+        package="mission_planner",
+        executable="goal_pose_visualizer",
+        name="goal_pose_visualizer",
+        output="screen",
+        remappings=[
+            ("input/route", LaunchConfiguration("route_topic_name")),
+            ("output/goal_pose", LaunchConfiguration("echo_back_goal_pose_topic_name")),
+        ],
+        parameters=[
+            {"use_sim_time": LaunchConfiguration("use_sim_time")},
+        ]
+    )
+
+    return LaunchDescription([
+        route_topic_name_arg,
+        echo_back_goal_pose_topic_name_arg,
+        goal_pose_visualizer_node
+    ])

--- a/planning/mission_planner/launch/mission_planner.launch.py
+++ b/planning/mission_planner/launch/mission_planner.launch.py
@@ -1,0 +1,61 @@
+# Copyright 2023 U Power Robotics, USA
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from ament_index_python.packages import get_package_share_directory
+import os
+
+
+def generate_launch_description():
+
+    mission_planner_share_path = get_package_share_directory("mission_planner")
+
+    # arguments
+    modified_goal_topic_name_arg = DeclareLaunchArgument(
+        name="modified_goal_topic_name",
+        default_value="/planning/scenario_planning/modified_goal",
+    )
+
+    map_topic_name_arg = DeclareLaunchArgument(
+        name="map_topic_name",
+        default_value="/map/vector_map",
+        description="lanelet2 map topic name",
+    )
+
+    visualization_topic_name_arg = DeclareLaunchArgument(
+        name="visualization_topic_name",
+        default_value="/planning/mission_planning/route_marker",
+    )
+
+    mission_planner_param_path_arg = DeclareLaunchArgument(
+        name="mission_planner_param_path",
+        default_value=os.path.join(mission_planner_share_path, "config/mission_planner.param.yaml"),
+    )
+
+    mission_planner_node = Node(
+        package="mission_planner",
+        executable="mission_planner",
+        name="mission_planner",
+        output="screen",
+        remappings=[
+            ("input/modified_goal", LaunchConfiguration("modified_goal_topic_name")),
+            ("input/vector_map", LaunchConfiguration("map_topic_name")),
+            ("debug/route_marker", LaunchConfiguration("visualization_topic_name")),
+            ("/localization/kinematic_state", LaunchConfiguration("odom_topic_name")),
+        ],
+        parameters=[
+            LaunchConfiguration("mission_planner_param_path"),
+            {"use_sim_time": LaunchConfiguration("use_sim_time")},
+            {"map_frame": LaunchConfiguration("map_frame_id")},
+        ],
+    )
+
+    return LaunchDescription([
+        modified_goal_topic_name_arg,
+        map_topic_name_arg,
+        visualization_topic_name_arg,
+        mission_planner_param_path_arg,
+        mission_planner_node
+    ])

--- a/planning/motion_velocity_smoother/launch/motion_velocity_smoother.launch.py
+++ b/planning/motion_velocity_smoother/launch/motion_velocity_smoother.launch.py
@@ -1,0 +1,107 @@
+# Copyright 2023 U Power Robotics, USA
+
+import os.path
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.actions import OpaqueFunction
+from launch.substitutions import LaunchConfiguration
+from ament_index_python.packages import get_package_share_directory
+
+
+def launch_setup(context, *args, **kwargs):
+    pkg_share_path = get_package_share_directory("motion_velocity_smoother")
+
+    # arguments
+    # common param
+    common_param_path_arg = DeclareLaunchArgument(
+        name="common_param_path",
+        default_value=os.path.join(
+            pkg_share_path, "config", "default_common.param.yaml"
+        ),
+    )
+
+    nearest_search_param_path_arg = DeclareLaunchArgument(
+        name="nearest_search_param_path",
+    )
+
+    # input/output
+    input_trajectory_arg = DeclareLaunchArgument(
+        name="input_trajectory",
+        default_value="/planning/scenario_planning/scenario_selector/trajectory",
+    )
+
+    output_trajectory_arg = DeclareLaunchArgument(
+        name="output_trajectory",
+        default_value="/planning/scenario_planning/trajectory",
+    )
+
+    # debug flags
+    publish_debug_trajs_arg = DeclareLaunchArgument(
+        name="publish_debug_trajs",
+        default_value="False",
+    )
+
+    smoother_type_arg = DeclareLaunchArgument(
+        name="smoother_type",
+        default_value="JerkFiltered",
+        description="Analytical, JerkFiltered, L2, or Linf",
+    )
+
+    param_path_arg = DeclareLaunchArgument(
+        name="param_path",
+        default_value=os.path.join(
+            pkg_share_path,
+            "config", "default_motion_velocity_smoother.param.yaml",
+        ),
+    )
+
+    smoother_param_path_arg = DeclareLaunchArgument(
+        name="smoother_param_path",
+        default_value=os.path.join(
+            pkg_share_path, "config", LaunchConfiguration("smoother_type").perform(context),
+            ".param.yaml"
+        ),
+    )
+
+    motion_velocity_smoother_node = Node(
+        package="motion_velocity_smoother",
+        executable="motion_velocity_smoother",
+        name="motion_velocity_smoother",
+        output="screen",
+        remappings=[
+            ("~/input/trajectory", LaunchConfiguration("input_trajectory")),
+            ("~/output/trajectory", LaunchConfiguration("output_trajectory")),
+            ("~/input/external_velocity_limit_mps",
+             "/planning/scenario_planning/max_velocity"),
+            # Topic for setting maximum speed from the outside (input topic)
+            ("~/output/current_velocity_limit_mps",
+             "/planning/scenario_planning/current_max_velocity"),
+            ("/localization/kinematic_state", LaunchConfiguration("odom_topic_name"))
+        ],
+        parameters=[
+            LaunchConfiguration("common_param_path"),
+            LaunchConfiguration("nearest_search_param_path"),
+            LaunchConfiguration("param_path"),
+            LaunchConfiguration("smoother_param_path"),
+            {"publish_debug_trajs": LaunchConfiguration("publish_debug_trajs")},
+            {"algorithm_type": LaunchConfiguration("smoother_type")},
+            {"use_sim_time": LaunchConfiguration("use_sim_time")},
+        ]
+    )
+
+    return [
+        common_param_path_arg,
+        nearest_search_param_path_arg,
+        input_trajectory_arg,
+        output_trajectory_arg,
+        publish_debug_trajs_arg,
+        smoother_type_arg,
+        param_path_arg,
+        smoother_param_path_arg,
+        motion_velocity_smoother_node
+    ]
+
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=launch_setup)])

--- a/planning/planning_validator/launch/planning_validator.launch.py
+++ b/planning/planning_validator/launch/planning_validator.launch.py
@@ -1,0 +1,56 @@
+# Copyright 2023 U Power Robotics, USA
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from ament_index_python.packages import get_package_share_directory
+import os
+
+
+def generate_launch_description():
+
+    pkg_share_path = get_package_share_directory("planning_validator")
+
+    # arguments
+    planning_validator_param_path_arg = DeclareLaunchArgument(
+        name="planning_validator_param_path",
+        default_value=os.path.join(
+            pkg_share_path,
+            "config/planning_validator.param.yaml"
+        ),
+    )
+
+    input_trajectory_arg = DeclareLaunchArgument(
+        name="input_trajectory",
+        default_value="/planning/scenario_planning/motion_velocity_smoother/trajectory",
+    )
+
+    output_trajectory_arg = DeclareLaunchArgument(
+        name="output_trajectory",
+        default_value="/planning/scenario_planning/trajectory"
+    )
+
+    planning_validator_node = Node(
+        package="planning_validator",
+        executable="planning_validator_node",
+        name="planning_validator",
+        output="screen",
+        remappings=[
+            ("~/input/trajectory", LaunchConfiguration("input_trajectory")),
+            ("~/input/kinematics", LaunchConfiguration("odom_topic_name")),
+            ("~/output/trajectory", LaunchConfiguration("output_trajectory")),
+            ("~/output/validation_status", "~/validation_status"),
+        ],
+        parameters=[
+            LaunchConfiguration("planning_validator_param_path"),
+            {"use_sim_time": LaunchConfiguration("use_sim_time")},
+        ],
+    )
+
+    return LaunchDescription([
+        planning_validator_param_path_arg,
+        input_trajectory_arg,
+        output_trajectory_arg,
+        planning_validator_node
+    ])

--- a/planning/rtc_auto_mode_manager/launch/rtc_auto_mode_manager.launch.py
+++ b/planning/rtc_auto_mode_manager/launch/rtc_auto_mode_manager.launch.py
@@ -1,0 +1,37 @@
+# Copyright 2023 U Power Robotics, USA
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from ament_index_python.packages import get_package_share_directory
+import os
+
+
+def generate_launch_description():
+
+    pkg_share_path = get_package_share_directory("rtc_auto_mode_manager")
+
+    # arguments
+    param_path_arg = DeclareLaunchArgument(
+        name="param_path",
+        default_value=os.path.join(pkg_share_path, "config/rtc_auto_mode_manager.param.yaml"),
+    )
+
+    rtc_auto_mode_manager_node = Node(
+        package="rtc_auto_mode_manager",
+        executable="rtc_auto_mode_manager_node",
+        name="rtc_auto_mode_manager",
+        output="screen",
+        parameters=[
+            LaunchConfiguration("param_path"),
+            {
+                "use_sim_time": LaunchConfiguration("use_sim_time"),
+            }
+        ],
+    )
+
+    return LaunchDescription([
+        param_path_arg,
+        rtc_auto_mode_manager_node
+    ])

--- a/planning/scenario_selector/launch/scenario_selector.launch.py
+++ b/planning/scenario_selector/launch/scenario_selector.launch.py
@@ -1,0 +1,86 @@
+# Copyright 2023 U Power Robotics, USA
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+
+
+def generate_launch_description():
+    # arguments
+    input_lane_driving_trajectory_arg = DeclareLaunchArgument(
+        name="input_lane_driving_trajectory",
+    )
+
+    input_parking_trajectory_arg = DeclareLaunchArgument(
+        name="input_parking_trajectory",
+    )
+
+    input_lanelet_map_arg = DeclareLaunchArgument(
+        name="input_lanelet_map",
+    )
+
+    input_route_arg = DeclareLaunchArgument(
+        name="input_route",
+    )
+
+    input_odometry_arg = DeclareLaunchArgument(
+        name="input_odometry",
+    )
+
+    is_parking_completed_arg = DeclareLaunchArgument(
+        name="is_parking_completed",
+    )
+
+    output_scenario_arg = DeclareLaunchArgument(
+        name="output_scenario",
+    )
+
+    output_trajectory_arg = DeclareLaunchArgument(
+        name="output_trajectory",
+    )
+
+    use_sim_time_arg = DeclareLaunchArgument(
+        name="use_sim_time",
+        default_value="False",
+        description="Use simulated time",
+    )
+
+    scenario_selector_node = Node(
+        package="scenario_selector",
+        executable="scenario_selector",
+        name="scenario_selector",
+        output="screen",
+        remappings=[
+            ("input/lane_driving/trajectory", LaunchConfiguration("input_lane_driving_trajectory")),
+            ("input/parking/trajectory", LaunchConfiguration("input_parking_trajectory")),
+            ("input/lanelet_map", LaunchConfiguration("input_lanelet_map")),
+            ("input/route", LaunchConfiguration("input_route")),
+            ("input/odometry", LaunchConfiguration("input_odometry")),
+            ("is_parking_completed", LaunchConfiguration("is_parking_completed")),
+
+            ("output/scenario", LaunchConfiguration("output_scenario")),
+            ("output/trajectory", LaunchConfiguration("output_trajectory")),
+        ],
+        parameters=[
+            {"update_rate": 10.0},
+            {"th_max_message_delay_sec": 1.0},
+            {"th_arrived_distance_m": 1.0},
+            {"th_stopped_time_sec": 1.0},
+            {"th_stopped_velocity_mps": 0.01},
+            {"use_sim_time": LaunchConfiguration("use_sim_time")}
+        ],
+    )
+
+    return LaunchDescription([
+        input_lane_driving_trajectory_arg,
+        input_parking_trajectory_arg,
+        input_lanelet_map_arg,
+        input_route_arg,
+        input_odometry_arg,
+        is_parking_completed_arg,
+        output_scenario_arg,
+        output_trajectory_arg,
+        use_sim_time_arg,
+        scenario_selector_node
+    ])

--- a/system/default_ad_api/CMakeLists.txt
+++ b/system/default_ad_api/CMakeLists.txt
@@ -5,25 +5,11 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
-  src/fail_safe.cpp
-  src/interface.cpp
-  src/localization.cpp
-  src/motion.cpp
-  src/operation_mode.cpp
-  src/planning.cpp
   src/routing.cpp
   src/utils/route_conversion.cpp
-  src/compatibility/autoware_state.cpp
 )
 
 rclcpp_components_register_nodes(${PROJECT_NAME}
-  "default_ad_api::AutowareStateNode"
-  "default_ad_api::FailSafeNode"
-  "default_ad_api::InterfaceNode"
-  "default_ad_api::LocalizationNode"
-  "default_ad_api::MotionNode"
-  "default_ad_api::OperationModeNode"
-  "default_ad_api::PlanningNode"
   "default_ad_api::RoutingNode"
 )
 

--- a/system/default_ad_api/launch/default_ad_api.launch.py
+++ b/system/default_ad_api/launch/default_ad_api.launch.py
@@ -13,14 +13,8 @@
 # limitations under the License.
 
 import launch
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer
-from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
-from launch_ros.parameter_descriptions import ParameterFile
-from launch_ros.substitutions import FindPackageShare
 import os
 from ament_index_python.packages import get_package_share_directory
 import yaml
@@ -42,13 +36,6 @@ def create_api_node(node_name, class_name, **kwargs):
 
 def generate_launch_description():
     components = [
-        create_api_node("autoware_state", "AutowareStateNode"),
-        create_api_node("fail_safe", "FailSafeNode"),
-        create_api_node("interface", "InterfaceNode"),
-        create_api_node("localization", "LocalizationNode"),
-        create_api_node("motion", "MotionNode"),
-        create_api_node("operation_mode", "OperationModeNode"),
-        create_api_node("planning", "PlanningNode"),
         create_api_node("routing", "RoutingNode"),
     ]
     container = ComposableNodeContainer(


### PR DESCRIPTION
1. Add python launch files for packages as follow: `external_velocity_limit_selector`, `mission_planner`, `motion_velocity_smoother`,  `planning_validator`,  `scenario_selector` and `rtc_auto_mode_manager`
2.  Modify `default_ad_api` package (only keep routing node)